### PR TITLE
Claudio/investigation

### DIFF
--- a/frontend/App.jsx
+++ b/frontend/App.jsx
@@ -16,6 +16,7 @@ const App = () => {
 
   useEffect(() => {
     async function setup() {
+    /*
       console.log("in setup");
       await web_development.deployBalances();
       console.log("after deployBalances");
@@ -23,7 +24,15 @@ const App = () => {
       console.log("after deployApp");
       await web_development.deployGovernor();
       console.log("after deployGovernor");
+    */
+      web_development.deployAll();
+      console.log("initiated deployAll");
+      while (!(await web_development.isReady())) {
+        await new Promise(r => setTimeout(r, 2000));
+        console.log("polled isReady");
+      };
       const auctionList = await web_development.getAuctions();
+      console.log("after getAuctions");
       console.log(auctionList);
       setItemList([auctionList[1].item]);
     }

--- a/frontend/App.jsx
+++ b/frontend/App.jsx
@@ -25,16 +25,17 @@ const App = () => {
       await web_development.deployGovernor();
       console.log("after deployGovernor");
     */
-      web_development.deployAll();
+      await web_development.deployAll(); // responds promptly
       console.log("initiated deployAll");
+      // poll until isReady()
       while (!(await web_development.isReady())) {
-        await new Promise(r => setTimeout(r, 2000));
         console.log("polled isReady");
+        await new Promise(r => setTimeout(r, 2000));
       };
       const auctionList = await web_development.getAuctions();
       console.log("after getAuctions");
       console.log(auctionList);
-      setItemList([auctionList[1].item]);
+      setItemList([auctionList[1].item]); // unrelated existing bug here?
     }
     setup();
   }, []);

--- a/src/Main.mo
+++ b/src/Main.mo
@@ -64,6 +64,21 @@ actor {
     }
   };
 
+  public func deployAll() : async () {
+    ignore async {
+      await deployBalances();
+      await deployApp();
+      await deployGovernor();
+    };
+  };
+
+  public query func isReady() : async Bool {
+    switch(balances, app, governor) {
+      case (? _, ? _, ? _) true;
+      case _ false;
+    }
+  };
+
   public func getAuctions() : async ([(AuctionId, Auction)]) {
     switch (app) {
       case (null) throw Prim.error("Should call deployApp() first");

--- a/src/Main.mo
+++ b/src/Main.mo
@@ -64,14 +64,16 @@ actor {
     }
   };
 
+  // deployAll() replies immediately after initiating but not awaiting the asynchronous deployments
   public func deployAll() : async () {
     ignore async {
       await deployBalances();
-      await deployApp();
-      await deployGovernor();
+      ignore deployApp(); // requires Balances
+      ignore deployGovernor(); // requires Balances
     };
   };
 
+  // isReady() replies promptly (and is a cheap query)
   public query func isReady() : async Bool {
     switch(balances, app, governor) {
       case (? _, ? _, ? _) true;


### PR DESCRIPTION
This is *a* fix, but I'm not sure its *the* fix.

Essentially, the JS calls to the replica appear to time out before the replica has a chance to complete the deployments.

This variant of the code pushed the deployments into an asynchronous function on `Main.mo` that spawns an async do the actual deployments, but does not await its result, thus returning promptly.

The main JS code now just calls `deployAll()` which also return quickly having queued some work in the replica, and then repeatedly  polls a query method until the actual deployment work is done. Each poll via `isReady()` completes promptly so there is no risk of timeout during polling either.

