### PR TITLE
reduce build times by making ts-loader rule more selective

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -61,7 +61,7 @@ function generateWebpackConfigForCanister(name, info) {
     // tutorial, uncomment the following lines:
     module: {
      rules: [
-       { test: /\.(js|ts)x?$/, loader: "ts-loader" },
+       { test: /\.(jsx|tsx?)$/, loader: "ts-loader" },
        { test: /\.css$/, use: ['style-loader','css-loader'] },
        {
         test: /\.(png|jpg|gif|svg|eot|ttf|woff|woff2)$/,


### PR DESCRIPTION
@nzoghb Hans suggested this fix for your high dfx build times, making `ts-loader` more selective.

https://dfinity.slack.com/archives/C016X3LCSLB/p1608167116127900

Brings build time from 1m40s to 20s on my machine...